### PR TITLE
Replaced "datetime64" for "datetime64[ns]" due to pandas warning

### DIFF
--- a/finlogic/company.py
+++ b/finlogic/company.py
@@ -196,9 +196,9 @@ class Company:
                     "fiscal_id": str,
                     "report_type": str,
                     "report_version": str,
-                    "period_reference": "datetime64",
-                    "period_begin": "datetime64",
-                    "period_end": "datetime64",
+                    "period_reference": "datetime64[ns]",
+                    "period_begin": "datetime64[ns]",
+                    "period_end": "datetime64[ns]",
                     "period_order": np.int8,
                     "acc_code": str,
                     "acc_name": str,
@@ -332,8 +332,8 @@ class Company:
         df.query(expression, inplace=True)
 
         # remove earnings per share from income statment
-        if report_type == 'income':
-            df = df[~df['acc_code'].str.startswith("3.99")]
+        if report_type == "income":
+            df = df[~df["acc_code"].str.startswith("3.99")]
 
         if report_type in {"income", "cash_flow"}:
             df = self._calculate_ttm(df)
@@ -476,7 +476,6 @@ class Company:
         net_debt = total_debt - total_cash
         invested_capital = total_debt + equity - total_cash
         invested_capital_p = self._prior_values(invested_capital, is_prior)
-
 
         # Output Dataframe (dfo)
         dfo = pd.DataFrame(columns=df.columns)

--- a/finlogic/database.py
+++ b/finlogic/database.py
@@ -233,10 +233,10 @@ def database_info() -> pd.DataFrame:
         c.main_df.drop_duplicates(subset=columns_duplicates).index
     )
     info_df.loc["First Financial Statement"] = (
-        c.main_df["period_end"].astype("datetime64").min().strftime("%Y-%m-%d")
+        c.main_df["period_end"].astype("datetime64[ns]").min().strftime("%Y-%m-%d")
     )
     info_df.loc["Last Financial Statement"] = (
-        c.main_df["period_end"].astype("datetime64").max().strftime("%Y-%m-%d")
+        c.main_df["period_end"].astype("datetime64[ns]").max().strftime("%Y-%m-%d")
     )
     return info_df
 


### PR DESCRIPTION
When using fl.database_info() and fl.Company(...), I get the following warning:

>/home/felipe/miniconda3/envs/aq_env/lib/python3.10/site-packages/finlogic/company.py:192: FutureWarning: Passing unit-less datetime64 dtype to .astype is deprecated and will raise in a future version. Pass 'datetime64[ns]' instead  .astype(

I replaced 'datetime64' for 'datetime64[ns], in both database.py and company.py.