### PR TITLE
Removed the conversion to datetime of the dataframe's columns.

### DIFF
--- a/finlogic/company.py
+++ b/finlogic/company.py
@@ -332,8 +332,8 @@ class Company:
         df.query(expression, inplace=True)
 
         # remove earnings per share from income statment
-        if report_type == 'income':
-            df = df[~df['acc_code'].str.startswith("3.99")]
+        if report_type == "income":
+            df = df[~df["acc_code"].str.startswith("3.99")]
 
         if report_type in {"income", "cash_flow"}:
             df = self._calculate_ttm(df)
@@ -477,7 +477,6 @@ class Company:
         invested_capital = total_debt + equity - total_cash
         invested_capital_p = self._prior_values(invested_capital, is_prior)
 
-
         # Output Dataframe (dfo)
         dfo = pd.DataFrame(columns=df.columns)
         dfo.loc["revenues"] = revenues
@@ -507,7 +506,7 @@ class Company:
         if num_years > 0:
             dfo = dfo[dfo.columns[-num_years:]]
         # Since all columns are strings representing corporate year, convert them to datetime64
-        dfo.columns = pd.to_datetime(dfo.columns)
+        # dfo.columns = pd.to_datetime(dfo.columns)
         return dfo
 
     def _make_report(self, dfi: pd.DataFrame) -> pd.DataFrame:


### PR DESCRIPTION
I got the following error: 

> [Error] ParserError: Unknown string format: 2022-09-30 (ttm) present at position 2
Traceback:
>---------------------------------------------------------------------------
>ParserError                               Traceback (most recent call last)
>File ~/miniconda3/envs/aq_env/lib/python3.10/site-packages/pandas/_libs/tslib.pyx:605, in >pandas._libs.tslib.array_to_datetime()
>File ~/miniconda3/envs/aq_env/lib/python3.10/site-packages/pandas/_libs/tslibs/parsing.pyx:318, in >pandas._libs.tslibs.parsing.parse_datetime_string()
>File ~/miniconda3/envs/aq_env/lib/python3.10/site-packages/dateutil/parser/_parser.py:1368, in >parse(timestr, parserinfo, **kwargs)
>   1367 else:
>-> 1368     return DEFAULTPARSER.parse(timestr, **kwargs)
>File ~/miniconda3/envs/aq_env/lib/python3.10/site-packages/dateutil/parser/_parser.py:643, in >parser.parse(self, timestr, default, ignoretz, tzinfos, **kwargs)
>    642 if res is None:
>--> 643     raise ParserError("Unknown string format: %s", timestr)
>    645 if len(res) == 0:
>ParserError: Unknown string format: 2022-09-30 (ttm)



In the indicators function, in the Company class, I commented the line where the columns were converted from strings to datetime. When there are quarterly financial statements, the corresponding column has its name expanded with the the string "(ttm)", indicating that columns does not contain annual values.  This raises an error.